### PR TITLE
Basic auth is now working!

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,9 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-//import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:follow_up_app/models/user.dart';
+//import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:follow_up_app/screens/wrapper.dart';
 import 'package:follow_up_app/services/auth.dart';
 import 'package:follow_up_app/shared/style_constants.dart';
@@ -32,11 +33,14 @@ class MyApp extends StatelessWidget {
 
           if (snapshot.connectionState != ConnectionState.done) return Loading();
 
+          AuthService.init();
+
           //this user data instance is only for authentication purposes, its id (from Firebase Auth) is not equivalent to the actual user id on Firestore
-          //todo: get final user object from Firestore, so that it can be consumed by other widgets
-          return StreamProvider<UserData?>.value(
-            value: AuthService.user,
-            initialData: null,
+          return MultiProvider(
+            providers: [
+              StreamProvider<User?>.value(value: AuthService.userStream, initialData: null),
+              StreamProvider<UserData?>.value(value: AuthService.signedInUser, initialData: null)
+            ],
             child: GetMaterialApp(
               theme: lightThemeConstant,
               darkTheme: darkThemeConstant,

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,6 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:follow_up_app/models/chat.dart';
+import 'package:follow_up_app/services/database.dart';
 
 //class containing general user data
 class UserData {
@@ -27,7 +27,7 @@ class UserData {
             phoneNumber: map?['phoneNumber'],
             birthDate: map?['birthDate'],
             profilePictureUrl: map?['profilePictureUrl'],
-            activeChatrooms: map?['activeChatrooms']);
+            activeChatrooms: (map?['activeChatrooms'] as List?)?.map((map) => DatabaseService.chatRoomCollection.doc(map.id)).toList() ?? []);
 
   Map<String, dynamic> toMap() => {
         'firstName': firstName,

--- a/lib/screens/authenticate/register.dart
+++ b/lib/screens/authenticate/register.dart
@@ -1,5 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -15,7 +14,6 @@ import 'package:follow_up_app/shared/shared.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:uuid/uuid.dart';
-import '../../main.dart';
 
 class Register extends StatefulWidget {
   final Function toggleView;
@@ -415,14 +413,15 @@ class _RegisterState extends State<Register> {
                                                   setState(() => loading = true);
 
                                                   await AuthService.registerWithEmailAndPassword(
-                                                      password,
-                                                      UserData(Uuid().v4(),
-                                                          firstName: firstName,
-                                                          lastName: lastName,
-                                                          email: email,
-                                                          country: country,
-                                                          phoneNumber: phoneNumber,
-                                                          birthDate: birthDate));
+                                                    UserData(Uuid().v4(),
+                                                        firstName: firstName,
+                                                        lastName: lastName,
+                                                        email: email,
+                                                        country: country,
+                                                        phoneNumber: phoneNumber,
+                                                        birthDate: birthDate),
+                                                    password,
+                                                  );
 
                                                   setState(() {
                                                     error = 'There was an error using these credential please retry';

--- a/lib/screens/mainMenu/main_menu.dart
+++ b/lib/screens/mainMenu/main_menu.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:follow_up_app/models/user.dart';
 import 'package:follow_up_app/screens/mainMenu/rides/home.dart';
 import 'package:follow_up_app/screens/mainMenu/statistics/statistics.dart';
 import 'package:follow_up_app/screens/mainMenu/settings/settings_page.dart';
 import 'package:follow_up_app/services/auth.dart';
+import 'package:follow_up_app/shared/loading.dart';
+import 'package:provider/provider.dart';
 import 'messaging/messaging.dart';
 
 class MainMenu extends StatefulWidget {
@@ -27,47 +30,51 @@ class _MainMenuState extends State<MainMenu> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      resizeToAvoidBottomInset: false,
-      body: Container(
-        color: Theme.of(context).secondaryHeaderColor,
-        width: double.infinity,
-        height: double.infinity,
-        child: _widgetOptions.elementAt(_selectedIndex),
-      ),
-      floatingActionButton: CircleAvatar(
-        radius: 30,
-        backgroundColor: Theme.of(context).accentColor,
-        child: IconButton(
-          iconSize: 30,
-          color: Colors.white,
-          alignment: Alignment.center,
-          icon: Icon(Icons.exit_to_app_rounded),
-          onPressed: () => AuthService.signOutAll(),
-        ),
-      ),
-      bottomNavigationBar: BottomNavigationBar(
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: Icon(Icons.home),
-            label: 'Home',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.show_chart),
-            label: 'Statistics',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.message_outlined),
-            label: 'Messages',
-          )
-        ],
-        currentIndex: _selectedIndex,
-        selectedItemColor: Theme.of(context).buttonColor,
-        onTap: _onItemTapped,
-      ),
-      drawer: Drawer(
-        child: SettingsPage(),
-      ),
-    );
+    UserData? user = Provider.of<UserData?>(context);
+
+    return user == null
+        ? Loading()
+        : Scaffold(
+            resizeToAvoidBottomInset: false,
+            body: Container(
+              color: Theme.of(context).secondaryHeaderColor,
+              width: double.infinity,
+              height: double.infinity,
+              child: _widgetOptions.elementAt(_selectedIndex),
+            ),
+            floatingActionButton: CircleAvatar(
+              radius: 30,
+              backgroundColor: Theme.of(context).accentColor,
+              child: IconButton(
+                iconSize: 30,
+                color: Colors.white,
+                alignment: Alignment.center,
+                icon: Icon(Icons.exit_to_app_rounded),
+                onPressed: () => AuthService.signOutAll(),
+              ),
+            ),
+            bottomNavigationBar: BottomNavigationBar(
+              items: const <BottomNavigationBarItem>[
+                BottomNavigationBarItem(
+                  icon: Icon(Icons.home),
+                  label: 'Home',
+                ),
+                BottomNavigationBarItem(
+                  icon: Icon(Icons.show_chart),
+                  label: 'Statistics',
+                ),
+                BottomNavigationBarItem(
+                  icon: Icon(Icons.message_outlined),
+                  label: 'Messages',
+                )
+              ],
+              currentIndex: _selectedIndex,
+              selectedItemColor: Theme.of(context).buttonColor,
+              onTap: _onItemTapped,
+            ),
+            drawer: Drawer(
+              child: SettingsPage(),
+            ),
+          );
   }
 }

--- a/lib/screens/mainMenu/messaging/messaging.dart
+++ b/lib/screens/mainMenu/messaging/messaging.dart
@@ -1,4 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:follow_up_app/models/chat.dart';
 import 'package:follow_up_app/models/user.dart';
@@ -6,7 +5,6 @@ import 'package:follow_up_app/screens/mainMenu/messaging/conversation.dart';
 import 'package:follow_up_app/screens/mainMenu/messaging/user_research.dart';
 import 'package:follow_up_app/services/database.dart';
 import 'package:follow_up_app/shared/loading.dart';
-import 'package:follow_up_app/shared/style_constants.dart';
 import 'package:provider/provider.dart';
 
 class Messaging extends StatefulWidget {

--- a/lib/screens/mainMenu/settings/settings_page.dart
+++ b/lib/screens/mainMenu/settings/settings_page.dart
@@ -21,7 +21,7 @@ class SettingsPage extends StatelessWidget {
           context: context,
           builder: (context) {
             return Container(
-              padding: EdgeInsets.only(left: 10.0*widthRatio, top: 10.0*heightRatio, right: 10.0*widthRatio, bottom: 10.0*heightRatio),
+              padding: EdgeInsets.only(left: 10.0 * widthRatio, top: 10.0 * heightRatio, right: 10.0 * widthRatio, bottom: 10.0 * heightRatio),
               decoration: BoxDecoration(
                 color: Theme.of(context).scaffoldBackgroundColor,
               ),
@@ -32,13 +32,13 @@ class SettingsPage extends StatelessWidget {
 
     return Scaffold(
       body: Padding(
-        padding: EdgeInsets.only(top: 50.0*heightRatio, left: 10.0*widthRatio, right: 10.0*widthRatio, bottom: 50.0*heightRatio),
+        padding: EdgeInsets.only(top: 50.0 * heightRatio, left: 10.0 * widthRatio, right: 10.0 * widthRatio, bottom: 50.0 * heightRatio),
         child: Column(
           children: <Widget>[
             SizedBox(
               width: contextWidth,
               child: Container(
-                padding: EdgeInsets.only(top: 10.0*heightRatio, left: 5.0*widthRatio, right: 5.0*widthRatio, bottom: 10.0*heightRatio),
+                padding: EdgeInsets.only(top: 10.0 * heightRatio, left: 5.0 * widthRatio, right: 5.0 * widthRatio, bottom: 10.0 * heightRatio),
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.all(Radius.circular(30.0)),
                   color: Theme.of(context).backgroundColor,
@@ -58,7 +58,7 @@ class SettingsPage extends StatelessWidget {
                         child: Row(
                           children: <Widget>[
                             Icon(Icons.account_circle),
-                            SizedBox(width: 8.0*widthRatio),
+                            SizedBox(width: 8.0 * widthRatio),
                             Text('Edit profile'),
                             Spacer(),
                             Icon(
@@ -72,7 +72,7 @@ class SettingsPage extends StatelessWidget {
                         child: Row(
                           children: <Widget>[
                             Icon(Icons.poll),
-                            SizedBox(width: 8.0*widthRatio),
+                            SizedBox(width: 8.0 * widthRatio),
                             Text('Unit type'),
                             Spacer(),
                             Icon(
@@ -103,7 +103,7 @@ class SettingsPage extends StatelessWidget {
             SizedBox(
               width: contextWidth,
               child: Container(
-                padding: EdgeInsets.only(top: 10.0*heightRatio, left: 5.0*widthRatio, right: 5.0*widthRatio, bottom: 10.0*heightRatio),
+                padding: EdgeInsets.only(top: 10.0 * heightRatio, left: 5.0 * widthRatio, right: 5.0 * widthRatio, bottom: 10.0 * heightRatio),
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.all(Radius.circular(30.0)),
                   color: Theme.of(context).backgroundColor,
@@ -125,7 +125,7 @@ class SettingsPage extends StatelessWidget {
                         child: Row(
                           children: <Widget>[
                             Icon(Icons.settings_display),
-                            SizedBox(width: 8.0*widthRatio),
+                            SizedBox(width: 8.0 * widthRatio),
                             Text('Display'),
                             Spacer(),
                             Icon(
@@ -143,8 +143,8 @@ class SettingsPage extends StatelessWidget {
               width: contextWidth,
               height: 20.0,
               child: FlatButton(
-                onPressed: () async {
-                  await _authService.signOut();
+                onPressed: () {
+                  AuthService.signOutAll();
                 },
                 child: Text('Sign Out'),
               ),

--- a/lib/screens/wrapper.dart
+++ b/lib/screens/wrapper.dart
@@ -1,21 +1,14 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:follow_up_app/models/user.dart';
 import 'package:follow_up_app/screens/authenticate/authenticate.dart';
 import 'package:follow_up_app/screens/mainMenu/main_menu.dart';
 import 'package:follow_up_app/services/localisation.dart';
 import 'package:provider/provider.dart';
 
-class Wrapper extends StatefulWidget {
-  Wrapper({Key? key}) : super(key: key);
-
-  @override
-  _WrapperState createState() => _WrapperState();
-}
-
-class _WrapperState extends State<Wrapper> {
+class Wrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final user = Provider.of<UserData?>(context);
+    final user = Provider.of<User?>(context);
 
     // return MainMenu or Authenticate widget
     if (user != null) {
@@ -25,17 +18,3 @@ class _WrapperState extends State<Wrapper> {
       return Authenticate();
   }
 }
-
-/* class Wrapper extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final user = Provider.of<UserData?>(context);
-
-    // return MainMenu or Authenticate widget
-    if (user != null) {
-      Localisation.getPermission();
-      return MainMenu();
-    } else
-      return Authenticate();
-  }
-} */


### PR DESCRIPTION
- 2 providers can now used, one with the Firebase user (simply check for authentication) and one with our `UserData`
- Created `init()` function for the `AuthService` to initialize our custom `UserData` stream
- Google, Facebook and Email all work as Auth Providers (cannot be used interchangeably: missing UI to tell it to the user)
- Added `try {} catch {}` to auth functions to avoid crashing (for now, will add fallbacks in the future) in case someone does try to use different providers
- Loading screen between sign in screen and home screen

- Fixed issue where parsing the `_JsonDocumentReference` failed when creating a new `UserData` from a `Map<>`

- A bit of refactoring!